### PR TITLE
Disable GPU to avoid Chromium errors on Linux

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,10 @@ const path = require("path");
 const Store = require("electron-store");
 const fs = require("fs");
 
+// Disable GPU to avoid Chromium errors on Linux (e.g., in WSL or minimal environments)
+app.commandLine.appendSwitch("disable-gpu");
+app.commandLine.appendSwitch("disable-software-rasterizer");
+
 const store = new Store({
   defaults: {
     playlistVisible: false,


### PR DESCRIPTION
Disable GPU to avoid Chromium errors on Linux